### PR TITLE
rename to Geo.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,6 @@ jobs:
         shell: julia --project=docs --color=yes {0}
         run: |
           using Documenter: DocMeta, doctest
-          using JuliaGeo
-          DocMeta.setdocmeta!(JuliaGeo, :DocTestSetup, :(using JuliaGeo); recursive=true)
-          doctest(JuliaGeo)
+          using Geo
+          DocMeta.setdocmeta!(Geo, :DocTestSetup, :(using Geo); recursive=true)
+          doctest(Geo)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 JuliaGeo contributors
+Copyright (c) 2024 Geo contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Geo"
 uuid = "4f75c4cc-f146-4713-b1b1-9323cfc49fb1"
-authors = ["JuliaGeo contributors"]
+authors = ["Geo contributors"]
 version = "0.0.1"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "JuliaGeo"
+name = "Geo"
 uuid = "4f75c4cc-f146-4713-b1b1-9323cfc49fb1"
 authors = ["JuliaGeo contributors"]
 version = "0.0.1"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# JuliaGeo
+# Geo
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeo.github.io/JuliaGeo.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeo.github.io/JuliaGeo.jl/dev/)
-[![Build Status](https://github.com/JuliaGeo/JuliaGeo.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/JuliaGeo.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/JuliaGeo/JuliaGeo.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaGeo/JuliaGeo.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeo.github.io/Geo.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeo.github.io/Geo.jl/dev/)
+[![Build Status](https://github.com/JuliaGeo/Geo.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/Geo.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaGeo/Geo.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaGeo/Geo.jl)
 
 A meta package for the JuliaGeo ecosystem.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-JuliaGeo = "4f75c4cc-f146-4713-b1b1-9323cfc49fb1"
+Geo = "4f75c4cc-f146-4713-b1b1-9323cfc49fb1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,14 @@
-using JuliaGeo
+using Geo
 using Documenter
 
-DocMeta.setdocmeta!(JuliaGeo, :DocTestSetup, :(using JuliaGeo); recursive=true)
+DocMeta.setdocmeta!(Geo, :DocTestSetup, :(using Geo); recursive=true)
 
 makedocs(;
-    modules=[JuliaGeo],
-    authors="JuliaGeo contributors",
-    sitename="JuliaGeo.jl",
+    modules=[Geo],
+    authors="Geo contributors",
+    sitename="Geo.jl",
     format=Documenter.HTML(;
-        canonical="https://JuliaGeo.github.io/JuliaGeo.jl",
+        canonical="https://JuliaGeo.github.io/Geo.jl",
         edit_link="main",
         assets=String[],
     ),
@@ -18,6 +18,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaGeo/JuliaGeo.jl",
+    repo="github.com/JuliaGeo/Geo.jl",
     devbranch="main",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,14 @@
 ```@meta
-CurrentModule = JuliaGeo
+CurrentModule = Geo
 ```
 
-# JuliaGeo
+# Geo
 
-Documentation for [JuliaGeo](https://github.com/JuliaGeo/JuliaGeo.jl).
+Documentation for [Geo](https://github.com/JuliaGeo/Geo.jl).
 
 ```@index
 ```
 
 ```@autodocs
-Modules = [JuliaGeo]
+Modules = [Geo]
 ```

--- a/src/Geo.jl
+++ b/src/Geo.jl
@@ -1,4 +1,4 @@
-module JuliaGeo
+module Geo
 
 # Write your package code here.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
-using JuliaGeo
+using Geo
 using Test
 
-@testset "JuliaGeo.jl" begin
+@testset "Geo.jl" begin
     # Write your tests here.
 end


### PR DESCRIPTION
As "Julia" isn't allowed in package names, and `Geo.function` is pretty nice syntax, no need for `import as`

We will need permission for the 3 letter name, but it should be fine.