### PR TITLE
use import

### DIFF
--- a/src/Geo.jl
+++ b/src/Geo.jl
@@ -1,26 +1,23 @@
 module Geo
 
-using ArchGDAL
 using DimensionalData
 using Extents
 using GeoDataFrames
 using GeoFormatTypes
 using GeoInterface
-using GeoInterfaceMakie
-using GeoInterfaceRecipes
-using GeoJSON
-using GeoParquet
 using GeometryOps
-using LibGEOS
-using NCDatasets
 using Proj
 using Rasters
-using Shapefile
-using WellKnownGeometry
-using ZarrDatasets
 
-using DimensionalData.Lookups
-using DimensionalData.Dimensions
-
+import ArchGDAL
+import GeoInterfaceMakie
+import GeoInterfaceRecipes
+import GeoJSON
+import GeoParquet
+import NCDatasets
+import LibGEOS
+import Shapefile
+import ZarrDatasets
+import WellKnownGeometry
 
 end


### PR DESCRIPTION
@asinghvi17 @evetion does this look right to you?

Mostly the `import` packages will be used by GeoDataFrames/Rasters/GeometryOps as backends, or just make plot recipes avaialvble